### PR TITLE
Paper: Fix plugin folder and config not being created

### DIFF
--- a/paper/src/main/java/com/hpfxd/spectatorplus/paper/SpectatorPlugin.java
+++ b/paper/src/main/java/com/hpfxd/spectatorplus/paper/SpectatorPlugin.java
@@ -10,8 +10,10 @@ public class SpectatorPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        if(!this.getDataFolder().exists() && !this.getDataFolder().mkdirs()) {
+            this.getLogger().warning("Could not create config folder. Check read/write permissions.");
+        }
         this.saveDefaultConfig();
-        this.reloadConfig();
         this.serverConfig = new ServerConfig(this.getConfig());
 
         this.syncController = new ServerSyncController(this);


### PR DESCRIPTION
The config was inaccessible due to the plugin folder not being created.

Also, a call to reloadConfig() is unnecessary in onEnable(), since the config is loaded at its most recent state.
Long-term it'd probably make sense to add a config reload command, where that can be used.
