### PR TITLE
Add showInvisibleEntities client setting

### DIFF
--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/config/ClientConfig.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/config/ClientConfig.java
@@ -7,6 +7,7 @@ public class ClientConfig {
     public boolean renderArms = true;
     public boolean showSpectators = true;
     public boolean highlightSpectators = true;
+    public boolean showInvisibleEntities = true;
     public boolean teleportAutoSpectate = false;
     public boolean openScreens = true;
     public boolean hideTooltipUntilMouseMove = false;

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/config/ClothConfigIntegration.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/config/ClothConfigIntegration.java
@@ -72,6 +72,11 @@ public class ClothConfigIntegration {
                 .setSaveConsumer(val -> config.highlightSpectators = val)
                 .build());
 
+        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("gui.spectatorplus.config.client.showInvisibleEntities.name"), config.showInvisibleEntities)
+                .setTooltip(Component.translatable("gui.spectatorplus.config.client.showInvisibleEntities.tooltip"))
+                .setSaveConsumer(val -> config.showInvisibleEntities = val)
+                .build());
+
         category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("gui.spectatorplus.config.client.teleportAutoSpectate.name"), config.teleportAutoSpectate)
                 .setTooltip(Component.translatable("gui.spectatorplus.config.client.teleportAutoSpectate.tooltip"))
                 .setSaveConsumer(val -> config.teleportAutoSpectate = val)

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/EntityMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/EntityMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.At;
 public class EntityMixin {
     @ModifyExpressionValue(method = "isInvisibleTo(Lnet/minecraft/world/entity/player/Player;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;isSpectator()Z"))
     private boolean spectatorplus$configShowInvisibleEntities(boolean original, @Local(argsOnly = true) Player player) {
-        if (player instanceof LocalPlayer && !SpectatorClientMod.config.showInvisibleEntities) {
+        if (player instanceof LocalPlayer && !SpectatorClientMod.config.showInvisibleEntities && !((Entity) (Object) this).isSpectator()) {
             return false;
         }
 

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/EntityMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/EntityMixin.java
@@ -1,0 +1,22 @@
+package com.hpfxd.spectatorplus.fabric.client.mixin;
+
+import com.hpfxd.spectatorplus.fabric.client.SpectatorClientMod;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Entity.class)
+public class EntityMixin {
+    @ModifyExpressionValue(method = "isInvisibleTo(Lnet/minecraft/world/entity/player/Player;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;isSpectator()Z"))
+    private boolean spectatorplus$configShowInvisibleEntities(boolean original, @Local(argsOnly = true) Player player) {
+        if (player instanceof LocalPlayer && !SpectatorClientMod.config.showInvisibleEntities) {
+            return false;
+        }
+
+        return original;
+    }
+}

--- a/fabric/src/client/resources/spectatorplus.client.mixins.json
+++ b/fabric/src/client/resources/spectatorplus.client.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "client": [
     "ClientLevelAccessor",
+    "EntityMixin",
     "GameRendererMixin",
     "GuiMixin",
     "ItemInHandRendererAccessor",

--- a/fabric/src/main/resources/assets/spectatorplus/lang/en_us.json
+++ b/fabric/src/main/resources/assets/spectatorplus/lang/en_us.json
@@ -16,6 +16,8 @@
   "gui.spectatorplus.config.client.showSpectators.tooltip": "Whether other players in spectator mode should be visible",
   "gui.spectatorplus.config.client.highlightSpectators.name": "Highlight Spectators",
   "gui.spectatorplus.config.client.highlightSpectators.tooltip": "Whether other players in spectator mode should\nbe highlighted when using the Vanilla\n\"%s\" keybind.",
+  "gui.spectatorplus.config.client.showInvisibleEntities.name": "Show Invisible Entities",
+  "gui.spectatorplus.config.client.showInvisibleEntities.tooltip": "Whether invisible entities will be rendered as\nhalf-transparent in spectator mode.",
   "gui.spectatorplus.config.client.teleportAutoSpectate.name": "Spectate when teleporting",
   "gui.spectatorplus.config.client.teleportAutoSpectate.tooltip": "Automatically start spectating players when teleporting\nusing the spectator hotbar menu.",
   "gui.spectatorplus.config.client.openScreens.name": "Open Synced Screens",


### PR DESCRIPTION
When disabled, the nametag and partially transparent body of invisible entities will not be shown. Other spectators will always be shown.

This setting is enabled by default, which matches Vanilla behavior.

Closes #3