### PR TITLE
Show block marker particles for spectators

### DIFF
--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/ClientLevelMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/ClientLevelMixin.java
@@ -1,0 +1,37 @@
+package com.hpfxd.spectatorplus.fabric.client.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.GameType;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ClientLevel.class)
+public class ClientLevelMixin {
+    @Shadow @Final private Minecraft minecraft;
+
+    @Redirect(method = "getMarkerParticleTarget()Lnet/minecraft/world/level/block/Block;", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;getPlayerMode()Lnet/minecraft/world/level/GameType;"))
+    private GameType spectatorplus$useCameraGameModeForMarkerParticleCheck(MultiPlayerGameMode instance) {
+        if (this.minecraft.cameraEntity instanceof Player player && player.isCreative()) {
+            return GameType.CREATIVE;
+        }
+
+        return instance.getPlayerMode();
+    }
+
+    @Redirect(method = "getMarkerParticleTarget()Lnet/minecraft/world/level/block/Block;", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getMainHandItem()Lnet/minecraft/world/item/ItemStack;"))
+    private ItemStack spectatorplus$useCameraForMarkerParticleCheck(LocalPlayer instance) {
+        if (this.minecraft.cameraEntity instanceof LivingEntity livingEntity) {
+            return livingEntity.getMainHandItem();
+        }
+        return ItemStack.EMPTY;
+    }
+}

--- a/fabric/src/client/resources/spectatorplus.client.mixins.json
+++ b/fabric/src/client/resources/spectatorplus.client.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "client": [
     "ClientLevelAccessor",
+    "ClientLevelMixin",
     "EntityMixin",
     "GameRendererMixin",
     "GuiMixin",


### PR DESCRIPTION
This patch shows block marker particles (the particles that show up when holding barrier and light blocks) when the spectated player is holding the item and is in creative mode.

Demo image (left side is the spectated client with [VisibleBarriers](https://modrinth.com/mod/visiblebarriers) installed, and the right side is the client spectating):
![image](https://github.com/hpfxd/SpectatorPlus/assets/31641700/d5fcf4b7-3d37-4dff-953d-a4bbcc7b6b25)
