### PR TITLE
Synced held map item data and rendering

### DIFF
--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/mixin/ServerPlayerMixin.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/mixin/ServerPlayerMixin.java
@@ -6,6 +6,7 @@ import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundExperienceSyncPacke
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundFoodSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundHotbarSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundSelectedSlotSyncPacket;
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;
@@ -81,5 +82,18 @@ public abstract class ServerPlayerMixin extends Player {
 
             this.setCamera(entity);
         }
+    }
+
+    /**
+     * Modify the receiver for calls to {@link ServerPlayer#getInventory()} for spectators to be for the spectated
+     * player's inventory instead. This allows held maps to be rendered.
+     */
+    @ModifyReceiver(method = "doTick()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;getInventory()Lnet/minecraft/world/entity/player/Inventory;"))
+    private ServerPlayer spectatorplus$syncMapData(ServerPlayer instance) {
+        if (instance.getCamera() instanceof ServerPlayer spectated) {
+            return spectated;
+        }
+
+        return instance;
     }
 }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/ServerSyncController.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/ServerSyncController.java
@@ -29,7 +29,7 @@ public class ServerSyncController {
         }
     }
 
-    private static Collection<ServerPlayer> getSpectators(Entity target) {
+    public static Collection<ServerPlayer> getSpectators(Entity target) {
         return ((ServerLevel) target.level()).getPlayers(spectator -> target != spectator && target.equals(spectator.getCamera()));
     }
 }

--- a/paper/src/main/java/com/hpfxd/spectatorplus/paper/sync/ServerSyncController.java
+++ b/paper/src/main/java/com/hpfxd/spectatorplus/paper/sync/ServerSyncController.java
@@ -8,6 +8,7 @@ import com.hpfxd.spectatorplus.paper.SpectatorPlugin;
 import com.hpfxd.spectatorplus.paper.sync.handler.ExperienceSyncHandler;
 import com.hpfxd.spectatorplus.paper.sync.handler.FoodSyncHandler;
 import com.hpfxd.spectatorplus.paper.sync.handler.InventorySyncHandler;
+import com.hpfxd.spectatorplus.paper.sync.handler.MapSyncHandler;
 import com.hpfxd.spectatorplus.paper.sync.handler.SelectedSlotSyncHandler;
 import com.hpfxd.spectatorplus.paper.sync.handler.screen.ScreenSyncHandler;
 import com.hpfxd.spectatorplus.paper.sync.packet.ServerboundOpenedInventorySyncPacket;
@@ -45,6 +46,7 @@ public class ServerSyncController implements PluginMessageListener {
         new FoodSyncHandler(plugin);
         this.inventorySyncHandler = new InventorySyncHandler(plugin);
         new SelectedSlotSyncHandler(plugin);
+        new MapSyncHandler(plugin);
     }
 
     public void sendPacket(Player receiver, ClientboundSyncPacket packet) {

--- a/paper/src/main/java/com/hpfxd/spectatorplus/paper/sync/handler/MapSyncHandler.java
+++ b/paper/src/main/java/com/hpfxd/spectatorplus/paper/sync/handler/MapSyncHandler.java
@@ -1,0 +1,74 @@
+package com.hpfxd.spectatorplus.paper.sync.handler;
+
+import com.destroystokyo.paper.event.player.PlayerStartSpectatingEntityEvent;
+import com.hpfxd.spectatorplus.paper.SpectatorPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.MapMeta;
+import org.bukkit.map.MapView;
+
+/**
+ * Handles syncing map item data to spectators.
+ * <p>
+ * When starting to spectate a player, the target's inventory is scanned for all maps and data is all sent to the
+ * spectator. Additionally, this is repeated every {@link MapSyncHandler#MAP_UPDATE_FREQUENCY} ticks for all players.
+ * <p>
+ * The {@code ClientboundMapItemDataPacket} has the ability to only re-send sections of maps which have changed since
+ * the last packet, but Bukkit does not have a reliable way for us to construct this and send it to spectators. Likely
+ * the best way to do this within the platform restrictions would be to inject into the Netty pipeline for spectated
+ * players and listen for the map packet, and send it to spectators directly there. This is not currently implemented.
+ * <p>
+ * Alternatively, the plugin could somehow detect when maps have been updated and re-send map data then instead of
+ * always at a fixed rate. The problem is that there is no way to send partial updates to the client, and something
+ * as simple as a player marker update which happens very often would need a full re-send anyway.
+ */
+public class MapSyncHandler implements Listener {
+    /**
+     * How often to re-send all maps to all spectators.
+     */
+    private static final int MAP_UPDATE_FREQUENCY = 30 * 20;
+
+    public MapSyncHandler(SpectatorPlugin plugin) {
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        Bukkit.getScheduler().runTaskTimer(plugin, this::updateAll, 0, MAP_UPDATE_FREQUENCY);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onStartSpectatingEntity(PlayerStartSpectatingEntityEvent event) {
+        final Player spectator = event.getPlayer();
+
+        if (event.getNewSpectatorTarget() instanceof final Player target) {
+           this.sendMaps(target, spectator);
+        }
+    }
+
+    private void updateAll() {
+        for (final Player spectator : Bukkit.getOnlinePlayers()) {
+            if (spectator.getSpectatorTarget() instanceof final Player target) {
+                this.sendMaps(target, spectator);
+            }
+        }
+    }
+
+    /**
+     * Send {@link MapView}s of all map items in spectated player's inventory to the spectator.
+     */
+    private void sendMaps(Player target, Player spectator) {
+        for (final ItemStack item : target.getInventory()) {
+            if (item != null && item.getType() == Material.FILLED_MAP && item.getItemMeta() instanceof final MapMeta mapMeta) {
+                if (mapMeta.hasMapView()) {
+                    final MapView view = mapMeta.getMapView();
+
+                    if (view != null) {
+                        spectator.sendMap(view);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Syncs the held map item data to spectators, and fixes arm rendering when the spectated player is holding a map (previously the arms were invisible).

On Fabric servers, this implementation sends an initial map data packet when the player starts spectating. Then, as any map update packets are sent to the target, the same packets are also sent to spectators.

On Paper servers, this is not possible to do without lots of reflection. Listening to packets sent to targets would also be needed unless the plugin also reimplemented how the map diff is sent. So instead, full map renders are sent to all spectators every 30 seconds.

Demo of this feature working (left is target, right is spectator):
![image](https://github.com/hpfxd/SpectatorPlus/assets/31641700/db0daa41-9316-4025-a347-489f6e4252f4)
