### PR TITLE
Update to Minecraft 1.21.5

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("fabric-loom") version "1.9-SNAPSHOT"
+    id("fabric-loom") version "1.10.1"
     id("spectatorplus.platform")
 }
 

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,13 +1,13 @@
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.9
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.16.14
 
 # Fabric API
-fabric_version=0.114.1+1.21.4
+fabric_version=0.125.0+1.21.5
 
-parchment_minecraft_version=1.21.4
-parchment_version=2025.01.05
+parchment_minecraft_version=1.21.5
+parchment_version=2025.04.19
 
 fabric_permissions_api_version=0.3.3
-cloth_config_version=17.0.144
-modmenu_version=13.0.0
+cloth_config_version=18.0.145
+modmenu_version=14.0.0-rc.2

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/config/ClothConfigIntegration.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/config/ClothConfigIntegration.java
@@ -10,9 +10,11 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 
 import java.io.IOException;
+import java.net.URI;
 
 public class ClothConfigIntegration {
     private ClothConfigIntegration() {
@@ -130,11 +132,13 @@ public class ClothConfigIntegration {
                 .setDefaultValue(defaults.allowTransferBetweenLevels)
                 .build());
 
-        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("gui.spectatorplus.config.server.autoUpdatePosition.name")
-                        .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://bugs.mojang.com/browse/MC-148993"))), config.autoUpdatePosition)
-                .setTooltip(Component.translatable("gui.spectatorplus.config.server.autoUpdatePosition.tooltip", Component.literal("MC-148993").withStyle(ChatFormatting.BLUE, ChatFormatting.UNDERLINE)))
-                .setSaveConsumer(val -> config.autoUpdatePosition = val)
-                .setDefaultValue(defaults.autoUpdatePosition)
-                .build());
+//        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("gui.spectatorplus.config.server.autoUpdatePosition.name")
+//                .withStyle(style -> style.withClickEvent(new ClickEvent.OpenUrl(URI.create("https://bugs.mojang.com/browse/MC-148993")))
+//                        .withHoverEvent(new HoverEvent.ShowText(Component.translatable("gui.spectatorplus.config.server.autoUpdatePosition.tooltip", Component.literal("MC-148993").withStyle(ChatFormatting.BLUE, ChatFormatting.UNDERLINE))))
+//
+////                .setSaveConsumer(val -> config.autoUpdatePosition = val)
+//                        // TODO: what
+//                        .setDefaultValue(defaults.autoUpdatePosition)
+//                        .build());
     }
 }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/config/ClothConfigIntegration.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/config/ClothConfigIntegration.java
@@ -10,7 +10,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 
 import java.io.IOException;
@@ -132,13 +131,11 @@ public class ClothConfigIntegration {
                 .setDefaultValue(defaults.allowTransferBetweenLevels)
                 .build());
 
-//        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("gui.spectatorplus.config.server.autoUpdatePosition.name")
-//                .withStyle(style -> style.withClickEvent(new ClickEvent.OpenUrl(URI.create("https://bugs.mojang.com/browse/MC-148993")))
-//                        .withHoverEvent(new HoverEvent.ShowText(Component.translatable("gui.spectatorplus.config.server.autoUpdatePosition.tooltip", Component.literal("MC-148993").withStyle(ChatFormatting.BLUE, ChatFormatting.UNDERLINE))))
-//
-////                .setSaveConsumer(val -> config.autoUpdatePosition = val)
-//                        // TODO: what
-//                        .setDefaultValue(defaults.autoUpdatePosition)
-//                        .build());
+        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("gui.spectatorplus.config.server.autoUpdatePosition.name")
+                .withStyle(style -> style.withClickEvent(new ClickEvent.OpenUrl(URI.create("https://bugs.mojang.com/browse/MC-148993")))), config.autoUpdatePosition)
+                .setTooltip(Component.translatable("gui.spectatorplus.config.server.autoUpdatePosition.tooltip", Component.literal("MC-148993").withStyle(ChatFormatting.BLUE, ChatFormatting.UNDERLINE)))
+                .setSaveConsumer(val -> config.autoUpdatePosition = val)
+                .setDefaultValue(defaults.autoUpdatePosition)
+                .build());
     }
 }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/gui/screens/SyncedInventoryScreen.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/gui/screens/SyncedInventoryScreen.java
@@ -1,5 +1,6 @@
 package com.hpfxd.spectatorplus.fabric.client.gui.screens;
 
+import com.hpfxd.spectatorplus.fabric.client.mixin.InventoryAccessor;
 import com.hpfxd.spectatorplus.fabric.client.mixin.screen.AbstractRecipeBookScreenAccessor;
 import com.hpfxd.spectatorplus.fabric.client.mixin.screen.ImageButtonAccessor;
 import net.minecraft.client.gui.components.ImageButton;
@@ -9,6 +10,7 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
+import net.minecraft.world.entity.EntityEquipment;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 
@@ -36,11 +38,11 @@ public class SyncedInventoryScreen extends InventoryScreen {
         final Inventory playerInventory = menu.getOwner().getInventory();
         final Inventory fakeInventory = menu.getInventory();
 
-        for (int slot = 0; slot < playerInventory.armor.size(); slot++) {
-            fakeInventory.armor.set(slot, playerInventory.armor.get(slot));
-        }
+        final EntityEquipment playerEquipment = ((InventoryAccessor) (menu.getOwner().getInventory())).getEquipment();
+        final EntityEquipment fakeEquipment = ((InventoryAccessor) (menu.getInventory())).getEquipment();
 
-        fakeInventory.offhand.set(0, playerInventory.offhand.get(0));
+        fakeEquipment.setAll(playerEquipment);
+        fakeInventory.setItem(Inventory.SLOT_OFFHAND, playerInventory.getItem(Inventory.SLOT_OFFHAND));
     }
 
     @Override

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GameRendererMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GameRendererMixin.java
@@ -46,7 +46,7 @@ public abstract class GameRendererMixin {
     @Unique private float xBobO;
     @Unique private float yBobO;
 
-    @Inject(method = "renderItemInHand(Lnet/minecraft/client/Camera;FLorg/joml/Matrix4f;)V", at = @At(value = "INVOKE", target = "Lorg/joml/Matrix4fStack;popMatrix()Lorg/joml/Matrix4fStack;"))
+    @Inject(method = "renderItemInHand(Lnet/minecraft/client/Camera;FLorg/joml/Matrix4f;)V", at = @At(value = "INVOKE", target = "Lorg/joml/Matrix4fStack;popMatrix()Lorg/joml/Matrix4fStack;", remap = false))
     public void spectatorplus$renderItemInHand(Camera camera, float partialTicks, Matrix4f matrix4f, CallbackInfo ci, @Local PoseStack poseStackIn) {
         if (SpectatorClientMod.config.renderArms && this.minecraft.player != null && this.minecraft.options.getCameraType().isFirstPerson() && !this.minecraft.options.hideGui) {
             final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GuiMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GuiMixin.java
@@ -16,7 +16,6 @@ import net.minecraft.client.gui.components.spectator.SpectatorGui;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -163,12 +162,12 @@ public abstract class GuiMixin {
         return (ClientSyncController.syncData != null && ClientSyncController.syncData.foodData != null) || SpecUtil.getCameraPlayer(this.minecraft) == null;
     }
 
-    @Redirect(method = "renderItemHotbar(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/player/Inventory;selected:I", opcode = Opcodes.GETFIELD))
+    @Redirect(method = "renderItemHotbar(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;getSelectedSlot()I", opcode = Opcodes.GETFIELD))
     private int spectatorplus$showSyncedSelectedSlot(Inventory inventory) {
         if (ClientSyncController.syncData != null && ClientSyncController.syncData.selectedHotbarSlot != -1 && SpecUtil.getCameraPlayer(this.minecraft) != null) {
             return ClientSyncController.syncData.selectedHotbarSlot;
         }
-        return inventory.selected;
+        return inventory.getSelectedSlot();
     }
 
     @Redirect(method = "renderFood(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/world/entity/player/Player;II)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;getFoodData()Lnet/minecraft/world/food/FoodData;"))
@@ -179,12 +178,12 @@ public abstract class GuiMixin {
         return instance.getFoodData();
     }
 
-    @ModifyReceiver(method = "renderItemHotbar(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/NonNullList;get(I)Ljava/lang/Object;", ordinal = 0))
-    private NonNullList<ItemStack> spectatorplus$showSyncedItems(NonNullList<ItemStack> instance, int i) {
+    @Redirect(method = "renderItemHotbar(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;getItem(I)Lnet/minecraft/world/item/ItemStack;"))
+    private ItemStack spectatorplus$showSyncedItems(Inventory instance, int slot) {
         if (ClientSyncController.syncData != null && ClientSyncController.syncData.selectedHotbarSlot != -1 && SpecUtil.getCameraPlayer(this.minecraft) != null) {
-            return ClientSyncController.syncData.hotbarItems;
+            return ClientSyncController.syncData.hotbarItems.get(slot);
         }
-        return instance;
+        return instance.getItem(slot);
     }
 
     @Redirect(method = "renderExperienceBar(Lnet/minecraft/client/gui/GuiGraphics;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getXpNeededForNextLevel()I"))
@@ -211,7 +210,7 @@ public abstract class GuiMixin {
         return instance.experienceLevel;
     }
 
-    @ModifyReceiver(method = "tick()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;getSelected()Lnet/minecraft/world/item/ItemStack;"))
+    @ModifyReceiver(method = "tick()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;getSelectedItem()Lnet/minecraft/world/item/ItemStack;"))
     private Inventory spectatorplus$modifyTooltipTick(Inventory instance) {
         if (this.minecraft.getCameraEntity() instanceof Player player) {
             return player.getInventory();

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/InventoryAccessor.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/InventoryAccessor.java
@@ -1,0 +1,12 @@
+package com.hpfxd.spectatorplus.fabric.client.mixin;
+
+import net.minecraft.world.entity.EntityEquipment;
+import net.minecraft.world.entity.player.Inventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Inventory.class)
+public interface InventoryAccessor {
+    @Accessor
+    EntityEquipment getEquipment();
+}

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncController.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncController.java
@@ -1,6 +1,7 @@
 package com.hpfxd.spectatorplus.fabric.client.sync.screen;
 
 import com.hpfxd.spectatorplus.fabric.client.gui.screens.SyncedInventoryScreen;
+import com.hpfxd.spectatorplus.fabric.client.mixin.InventoryAccessor;
 import com.hpfxd.spectatorplus.fabric.client.util.SpecUtil;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundInventorySyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundScreenCursorSyncPacket;
@@ -14,6 +15,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.MenuAccess;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.NonNullList;
+import net.minecraft.world.entity.EntityEquipment;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -120,10 +122,11 @@ public class ScreenSyncController {
             return false;
         }
 
-        syncedInventory = new Inventory(spectated);
+        EntityEquipment equipment = ((InventoryAccessor)spectated.getInventory()).getEquipment();
+        syncedInventory = new Inventory(spectated, equipment);
 
         for (int i = 0; i < syncData.screen.inventoryItems.size(); i++) {
-            syncedInventory.items.set(i, syncData.screen.inventoryItems.get(i));
+            syncedInventory.setItem(i, syncData.screen.inventoryItems.get(i));
         }
         return true;
     }

--- a/fabric/src/client/resources/spectatorplus.client.mixins.json
+++ b/fabric/src/client/resources/spectatorplus.client.mixins.json
@@ -26,7 +26,8 @@
     "screen.ImageButtonAccessor",
     "screen.InventoryMenuMixin",
     "screen.InventoryScreenMixin",
-    "screen.MenuScreensMixin"
+    "screen.MenuScreensMixin",
+    "InventoryAccessor"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric/src/client/resources/spectatorplus.client.mixins.json
+++ b/fabric/src/client/resources/spectatorplus.client.mixins.json
@@ -9,6 +9,7 @@
     "GameRendererAccessor",
     "GameRendererMixin",
     "GuiMixin",
+    "InventoryAccessor",
     "ItemInHandRendererAccessor",
     "ItemInHandRendererMixin",
     "LevelRendererAccessor",
@@ -26,8 +27,7 @@
     "screen.ImageButtonAccessor",
     "screen.InventoryMenuMixin",
     "screen.InventoryScreenMixin",
-    "screen.MenuScreensMixin",
-    "InventoryAccessor"
+    "screen.MenuScreensMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/mixin/ServerGamePacketListenerImplMixin.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/mixin/ServerGamePacketListenerImplMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class ServerGamePacketListenerImplMixin {
     @Shadow public ServerPlayer player;
 
-    @Inject(method = "handleSetCarriedItem(Lnet/minecraft/network/protocol/game/ServerboundSetCarriedItemPacket;)V", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/player/Inventory;selected:I", opcode = Opcodes.PUTFIELD))
+    @Inject(method = "handleSetCarriedItem(Lnet/minecraft/network/protocol/game/ServerboundSetCarriedItemPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;setSelectedSlot(I)V"))
     private void spectatorplus$syncSelectedSlot(ServerboundSetCarriedItemPacket packet, CallbackInfo ci) {
         ServerSyncController.broadcastPacketToSpectators(this.player, new ClientboundSelectedSlotSyncPacket(this.player.getUUID(), packet.getSlot()));
     }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/mixin/ServerPlayerMixin.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/mixin/ServerPlayerMixin.java
@@ -68,7 +68,7 @@ public abstract class ServerPlayerMixin extends Player {
             ServerSyncController.sendPacket(spectator, ClientboundSelectedSlotSyncPacket.initializing(target));
 
             // Send initial map data patch packet if the target has a map in inventory
-            for (final ItemStack stack : target.getInventory().items) {
+            for (final ItemStack stack : target.getInventory().getNonEquipmentItems()) {
                 if (stack.is(Items.FILLED_MAP)) {
                     final MapId mapId = stack.get(DataComponents.MAP_ID);
                     final MapItemSavedData mapItemSavedData = MapItem.getSavedData(mapId, this.level());

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/CustomPacketCodecs.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/CustomPacketCodecs.java
@@ -5,7 +5,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.ItemStack;
 
 import java.io.ByteArrayInputStream;
@@ -13,9 +12,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 public final class CustomPacketCodecs {
-    public static final StreamCodec<RegistryFriendlyByteBuf, ItemStack> ITEM_CODEC = StreamCodec.of(CustomPacketCodecs::writeItem, CustomPacketCodecs::readItem);
-    public static final StreamCodec<RegistryFriendlyByteBuf, ItemStack[]> ITEM_ARRAY_CODEC = StreamCodec.of(CustomPacketCodecs::writeItems, CustomPacketCodecs::readItems);
-
     private CustomPacketCodecs() {
     }
 

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/CustomPacketCodecs.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/CustomPacketCodecs.java
@@ -1,9 +1,21 @@
 package com.hpfxd.spectatorplus.fabric.sync;
 
+import io.netty.handler.codec.EncoderException;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.ItemStack;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
 public final class CustomPacketCodecs {
+    public static final StreamCodec<RegistryFriendlyByteBuf, ItemStack> ITEM_CODEC = StreamCodec.of(CustomPacketCodecs::writeItem, CustomPacketCodecs::readItem);
+    public static final StreamCodec<RegistryFriendlyByteBuf, ItemStack[]> ITEM_ARRAY_CODEC = StreamCodec.of(CustomPacketCodecs::writeItems, CustomPacketCodecs::readItems);
+
     private CustomPacketCodecs() {
     }
 
@@ -35,10 +47,42 @@ public final class CustomPacketCodecs {
     }
 
     public static ItemStack readItem(RegistryFriendlyByteBuf buf) {
-        return ItemStack.OPTIONAL_STREAM_CODEC.decode(buf);
+        final int len = buf.readInt();
+        if (len == 0) {
+            return ItemStack.EMPTY;
+        }
+
+        try {
+            final byte[] in = new byte[len];
+            buf.readBytes(in);
+
+            final CompoundTag tag = NbtIo.readCompressed(new ByteArrayInputStream(in), NbtAccounter.unlimitedHeap());
+            return ItemStack.parse(buf.registryAccess(), tag).orElse(ItemStack.EMPTY);
+        } catch (IOException e) {
+            throw new EncoderException(e);
+        }
     }
 
     public static void writeItem(RegistryFriendlyByteBuf buf, ItemStack item) {
-        ItemStack.OPTIONAL_STREAM_CODEC.encode(buf, item);
+        if (item.isEmpty()) {
+            buf.writeInt(0);
+            return;
+        }
+
+        final byte[] bytes;
+        try {
+            final CompoundTag tag = new CompoundTag();
+            item.save(buf.registryAccess(), tag);
+
+            final ByteArrayOutputStream out = new ByteArrayOutputStream();
+            NbtIo.writeCompressed(tag, out);
+
+            bytes = out.toByteArray();
+        } catch (IOException e) {
+            throw new EncoderException(e);
+        }
+
+        buf.writeInt(bytes.length);
+        buf.writeBytes(bytes);
     }
 }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundSelectedSlotSyncPacket.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundSelectedSlotSyncPacket.java
@@ -21,7 +21,7 @@ public record ClientboundSelectedSlotSyncPacket(
     public static final CustomPacketPayload.Type<ClientboundSelectedSlotSyncPacket> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.parse("spectatorplus:selected_slot_sync"));
 
     public static ClientboundSelectedSlotSyncPacket initializing(ServerPlayer target) {
-        return new ClientboundSelectedSlotSyncPacket(target.getUUID(), target.getInventory().selected);
+        return new ClientboundSelectedSlotSyncPacket(target.getUUID(), target.getInventory().getSelectedSlot());
     }
 
     public ClientboundSelectedSlotSyncPacket(FriendlyByteBuf buf) {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -51,13 +51,13 @@
   ],
   "depends": {
     "fabricloader": ">=0.15.0",
-    "minecraft": "~1.21.3",
+    "minecraft": "~1.21.5",
     "java": ">=21",
     "fabric-api": "*",
     "fabric-permissions-api-v0": "*"
   },
   "suggests": {
-    "cloth-config": "^17.0.0",
-    "modmenu": "^13.0.0"
+    "cloth-config": "^18.0.145",
+    "modmenu": "^14.0.0-rc.2"
   }
 }


### PR DESCRIPTION
For some reason, after updating the game version when using the paper plugin, the calls to `ItemStack.OPTIONAL_STREAM_CODEC.decode` were failing. I can't find what seams to be causing this, so I just reverted to the previous manual implementation for `readItem` and `writeItem`.

<details><summary>The Error</summary>
<p>

```
java.lang.IllegalArgumentException: No value with id 15200
	at knot//net.minecraft.core.IdMap.byIdOrThrow(IdMap.java:19)
	at knot//net.minecraft.network.codec.ByteBufCodecs$27.decode(ByteBufCodecs.java:561)
	at knot//net.minecraft.network.codec.ByteBufCodecs$27.decode(ByteBufCodecs.java:553)
	at knot//net.minecraft.world.item.ItemStack$1.decode(ItemStack.java:160)
	at knot//net.minecraft.world.item.ItemStack$1.decode(ItemStack.java:152)
	at knot//net.minecraft.world.item.ItemStack$2.decode(ItemStack.java:182)
	at knot//net.minecraft.world.item.ItemStack$2.decode(ItemStack.java:179)
	at knot//com.hpfxd.spectatorplus.fabric.sync.CustomPacketCodecs.readItem(CustomPacketCodecs.java:50)
	at knot//com.hpfxd.spectatorplus.fabric.sync.CustomPacketCodecs.readItems(CustomPacketCodecs.java:24)
	at knot//com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundHotbarSyncPacket.<init>(ClientboundHotbarSyncPacket.java:35)
	at knot//net.minecraft.network.codec.StreamCodec$2.decode(StreamCodec.java:40)
	at knot//net.minecraft.network.protocol.common.custom.CustomPacketPayload$1.decode(CustomPacketPayload.java:63)
	at knot//net.minecraft.network.protocol.common.custom.CustomPacketPayload$1.decode(CustomPacketPayload.java:39)
	at knot//net.minecraft.network.codec.StreamCodec$4.decode(StreamCodec.java:79)
	at knot//net.minecraft.network.codec.StreamCodec$5.decode(StreamCodec.java:94)
	at knot//net.minecraft.network.codec.StreamCodec$5.decode(StreamCodec.java:90)
	at knot//net.minecraft.network.codec.IdDispatchCodec.decode(IdDispatchCodec.java:36)
	at knot//net.minecraft.network.codec.IdDispatchCodec.decode(IdDispatchCodec.java:14)
	at knot//net.minecraft.network.PacketDecoder.decode(PacketDecoder.java:33)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202)
	at knot//io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:164)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:455)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
	at knot//io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799)
	at knot//io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:501)
	at knot//io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:399)
	at knot//io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at knot//io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1583)
``` 

</p>
</details> 

After trying the previous release of Minecraft 1.21.4 on a paper server with the plugin installed, the same function is failing. I guess this is the bug mentioned in #16 and #18? I'm very confused, but everything seams to be working after the reversion.